### PR TITLE
Hide un-useful fields in shelter index view. Added two new private fields.

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -1,11 +1,11 @@
 class SheltersController < ApplicationController
-  before_action :set_headers
+  before_action :set_headers, except: [:index]
   before_action :set_shelter, only: [:show, :edit, :update, :destroy, :archive]
 
   def index
+    set_index_headers
     @shelters = Shelter.all
     @page = Page.shelters.first_or_initialize
-
   end
 
   def new
@@ -78,11 +78,24 @@ class SheltersController < ApplicationController
   # This is the definition of a beautiful hack. 1 part gross, 2 parts simplicity. Does something neat not clever.
   def set_headers
     if(admin?)
-      @columns = Shelter::ColumnNames + Shelter::PrivateFields
-      @headers = Shelter::HeaderNames + Shelter::PrivateFields.map(&:titleize)
+      columns = Shelter::ColumnNames + Shelter::PrivateFields
+      @columns = columns
+      @headers = columns.map(&:titleize)
     else
       @columns = Shelter::ColumnNames
-      @headers = Shelter::HeaderNames
+      @headers = Shelter::ColumnNames.map(&:titleize)
+    end
+  end
+
+  def set_index_headers
+    if(admin?)
+      columns = (Shelter::ColumnNames + Shelter::PrivateFields) - Shelter::IndexHiddenColumnNames
+      @columns = columns
+      @headers = columns.map(&:titleize)
+    else
+      columns = Shelter::ColumnNames - Shelter::IndexHiddenColumnNames
+      @columns = columns
+      @headers = columns.map(&:titleize)
     end
   end
 

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -6,6 +6,19 @@ class Shelter < ApplicationRecord
     longitude special_needs
   ]
 
+  # columns to hide in index view
+  IndexHiddenColumnNames = %w[
+    address_name
+    city
+    state
+    county
+    zip
+    google_place_id
+    latitude
+    longitude
+    notes
+  ]
+
   HeaderNames = ColumnNames.map(&:titleize)
 
   UpdateFields = %w[
@@ -14,7 +27,12 @@ class Shelter < ApplicationRecord
     food_pantry latitude longitude google_place_id special_needs
   ]
 
-  PrivateFields = %w[private_notes private_email]
+  PrivateFields = %w[
+    private_notes
+    private_email
+    private_sms
+    private_volunteer_data_mgr
+  ]
 
   has_many :drafts, as: :record
   default_scope { where(active: !false) }

--- a/app/views/shelters/_form.html.erb
+++ b/app/views/shelters/_form.html.erb
@@ -75,6 +75,12 @@
 
       <%= f.label :private_email %>
       <%= f.text_field :private_email %>
+
+      <%= f.label :private_sms %>
+      <%= f.text_field :private_sms %>
+
+      <%= f.label :private_volunteer_data_mgr %>
+      <%= f.text_field :private_volunteer_data_mgr %>
     <% end %>
 
     <%= f.button :submit %>

--- a/db/migrate/20170909174720_add_private_fields_to_shelters.rb
+++ b/db/migrate/20170909174720_add_private_fields_to_shelters.rb
@@ -1,0 +1,6 @@
+class AddPrivateFieldsToShelters < ActiveRecord::Migration[5.1]
+  def change
+    add_column :shelters, :private_sms, :string
+    add_column :shelters, :private_volunteer_data_mgr, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170909082743) do
+ActiveRecord::Schema.define(version: 20170909174720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -167,6 +167,8 @@ ActiveRecord::Schema.define(version: 20170909082743) do
     t.string "google_place_id"
     t.boolean "special_needs"
     t.string "private_email"
+    t.string "private_sms"
+    t.string "private_volunteer_data_mgr"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
NOT READY FOR REVIEW. DO NOT MERGE.

Per https://github.com/Irma-Response/irma-api/issues/5, this PR:

* Removes columns from the shelter index view that are not useful. These columns are still available in the "show" and "update" views for shelters.
* Adds two new columns, `private_sms` and `private_volunteer_data_mgr`