### PR TITLE
rearrange controls to make it easier for editors

### DIFF
--- a/app/views/shelters/_form.html.erb
+++ b/app/views/shelters/_form.html.erb
@@ -15,6 +15,8 @@
   <fieldset>
     <div class="row">
       <div class="column">
+        <%= f.button :submit %>
+
         <label><%= f.check_box :accepting %> Accepting</label>
         <%= f.label :google_place, 'Where is it?' %>
         <%= f.text_field :google_place, :value => f.object.address, :class => 'place-autocomplete', :data => {
@@ -68,14 +70,14 @@
     <%= f.label :pets %>
     <%= f.text_area :pets %>
 
+    <%= f.label :notes %>
+    <%= f.text_area :notes %>
+
     <%= f.label :supply_needs %>
     <%= f.text_area :supply_needs %>
 
     <%= f.label :volunteer_needs %>
     <%= f.text_area :volunteer_needs %>
-
-    <%= f.label :notes %>
-    <%= f.text_area :notes %>
 
     <%= f.label :distribution_center %>
     <%= f.text_field :distribution_center %>


### PR DESCRIPTION
1- Move notes above `Supply needs` and below `Pets`
2- Add submit button on the top

user story from @wslack:
```I get a notice that a shelter closed. I want to open the record, close the shelter, paste a citation, and GTFO.```