### PR TITLE
Allow Hidden Columns to be Searched

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -88,15 +88,10 @@ class SheltersController < ApplicationController
   end
 
   def set_index_headers
-    if(admin?)
-      columns = (Shelter::ColumnNames + Shelter::PrivateFields) - Shelter::IndexHiddenColumnNames
-      @columns = columns
-      @headers = columns.map(&:titleize)
-    else
-      columns = Shelter::ColumnNames - Shelter::IndexHiddenColumnNames
-      @columns = columns
-      @headers = columns.map(&:titleize)
-    end
+    @columns = Shelter::ColumnNames
+    @columns += Shelter::PrivateFields if admin?
+    @headers = @columns.map(&:titleize)
+    @hidden_headers = Shelter::IndexHiddenColumnNames.map(&:titleize)
   end
 
   def set_shelter

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -1,9 +1,12 @@
+<% hidden_headers ||= [] %>
 <table id="data-table" class="shared-table">
   <thead>
     <tr>
       <th></th>
       <% headers.each do |header| %>
-        <th><%= header %></th>
+        <th class="<%= hidden_headers.include?(header) ? 'hidden' : '' %>">
+          <%= header %>
+        </th>
       <% end %>
     </tr>
   </thead>
@@ -24,7 +27,10 @@
  window.onload = function() {
    $('#data-table').DataTable({
      "order": [[ 1, "desc" ]],
-     "stateSave": true
+     "stateSave": true,
+     "columnDefs": [
+       { "targets": "hidden", "visible": false },
+     ]
    });
  };
 </script>

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -36,7 +36,7 @@
      },
      "columnDefs": [
        {
-         "targets": <%= hidden_headers.map { |hh| headers.index(hh) } %>,
+         "targets": <%= JSON.generate(hidden_headers.map { |hh| headers.index(hh) }) %>,
          "visible": false
        },
      ]

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -28,6 +28,14 @@
    $('#data-table').DataTable({
      "order": [[ 1, "desc" ]],
      "stateSave": true,
+     "stateSaveParams": function (settings, data) {
+       const savableKeys = ["search"]
+       Object.keys(data).forEach(function(key) {
+         if (!savableKeys.includes(key)) {
+           delete data[key]
+         }
+       })
+     },
      "columnDefs": [
        { "targets": "hidden", "visible": false },
      ]

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -4,9 +4,7 @@
     <tr>
       <th></th>
       <% headers.each do |header| %>
-        <th class="<%= hidden_headers.include?(header) ? 'hidden' : '' %>">
-          <%= header %>
-        </th>
+          <th><%= header %></th>
       <% end %>
     </tr>
   </thead>
@@ -37,7 +35,10 @@
        })
      },
      "columnDefs": [
-       { "targets": "hidden", "visible": false },
+       {
+         "targets": <%= hidden_headers.map { |hh| headers.index(hh) } %>,
+         "visible": false
+       },
      ]
    });
  };

--- a/app/views/shelters/index.html.erb
+++ b/app/views/shelters/index.html.erb
@@ -27,4 +27,4 @@
 
 <%= link_to 'Add New Shelter', new_shelter_path, class: "button button-outline" %>
 
-<%= render "shared/table", rows: @shelters, headers: @headers, columns: @columns %>
+<%= render "shared/table", rows: @shelters, headers: @headers, columns: @columns, hidden_headers: @hidden_headers %>


### PR DESCRIPTION
This leverages [DataTable's hidden columns feature](https://datatables.net/examples/basic_init/hidden_columns.html) to hide the hidden columns client side, but still allow them to be searched to implement the ask in https://github.com/Irma-Response/irma-api/issues/41. 

It's a little crappy that the table first renders with the columns and then they disappear, but that was already a problem with the client side ordering (i.e. `"order": [[ 1, "desc" ]]`). We should be able to fix both by having the table not display until DataTable is done loading, but that is out of scope of this change.

Another problem is that `"stateSave": true` causes new DataTable options to not be pick up by the browser unless the local storage is cleared (too me way too long to realized why it was not working). Not sure if there is a better way to auto-clear the local storage on deployments, but worst case we should inform users how to clear it themselves. Another option would be to use the session storage instead, or maybe just nothing at all if we don't really need it. cc @rogerroelofs who added this.